### PR TITLE
Fail plugin registration if initial connection fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,12 +9,29 @@ exports.register = function (server, options, next) {
 
   var redisClient = redisClientFactory(redis, options);
 
-  redisClient.on("error", function(err){
+  /**
+   * error handler for errors after initial connection has been established 
+   * @param {Error} err is the error thrown
+   * @return {null}
+   */
+  var defaultErrorHandler = function(err) {
     server.log([ 'hapi-redis', 'error' ], err.message);
-  });
+  };
+
+  var initialErrorHandler = function(err) {
+    server.log([ 'hapi-redis', 'error' ], err.message);
+    next(err);
+    redisClient.end();
+  };
+  
+  redisClient.on('error', initialErrorHandler);
 
   redisClient.on("ready", function(){
     server.log([ 'hapi-redis', 'info' ], 'redisClient connection created');
+    
+    // change the error handler to simply log errors
+    redisClient.removeListener('error', initialErrorHandler); 
+    redisClient.on('error', defaultErrorHandler);
     next();
   });
 

--- a/test/connection.js
+++ b/test/connection.js
@@ -19,4 +19,16 @@ describe('Hapi server', function() {
       })
     });
   });
+  it('should throw error if redis connection fails', function(done) {
+    var server = new Hapi.Server();
+    server.register({
+      register: redisPlugin,
+      options: {
+        host: 'invalid'
+      }
+    }, function (err) {
+      assert(err instanceof Error, 'No error thrown for failed connection')
+      done()
+    });
+  });
 });


### PR DESCRIPTION
Thanks for providing this great little plugin. I would like to contribute to your efforts with this PR, which solves #5. Please let me know if you have any feedback on this.
# Problem

As stated by @djensen47, if the initial connection attempts to the redis server fail, Hapi will wait indefinitely for the plugin to register. This results in the server hanging before starting itself up: a condition which could be difficult for monitoring tools to detect.
# Solution

As @sandfox suggests, I call `next(err)` with the connection error in the event of a problem when establishing the initial connection. This should only be done if a _error_ event occurs before the _ready_ event (errors occurring after the connection has been established are more of an application-specific problem). 

To ensure that this happens, the error handler is initially set to be a function which calls `next(err)`, thus propagating the error to the `server.register()` callback. However, if the _ready_ handler is called before the _error_ handler, it will remove the aforementioned error-handler, and add a new error-handler that simply logs the error. 
# Discussion

I actually rewrote this change completely once. The first implementation used a variable to track whether a connection had been established initially, then optionally calling `next(err)` within the error-handler if it was set to `false`. While this works, it requires storing more state than necessary inside of the plugin, and could slow down the thread by evaluating the condition on every error.  
