### PR TITLE
added optional promise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ __With 6.x.x the `options` object has changed it's signature__
 
 Options:
 - `redisLibrary`:  passing in a `redis` module to override the one bundled with this module. optional.
+- `enablePromises` enables promise support for the default library. Note that this option has no effect when specifying a `redisLibrary` of your own. optional.
 - `connection`: an object or string that is passed through to [basic-redis-factory](https://github.com/sandfox/node-basic-redis-factory/tree/v0.0.3#api) as the 2nd argument. The relevant part of the docs are reproduced here for ease of reference:
 
 `connection` can either be a url connection string (i.e `redis://user:password@127.0.0.1:6379`) or an object.
@@ -94,3 +95,6 @@ server.start(function() {
     console.log("Server started at " + server.info.uri);
 });
 ```
+
+## Promise Support
+To enable Promise support for the default Redis Library (node_redis), you may pass `enablePromises: true` in your plugin options. All original methods will now be suffixed with `Async`. For example, you would now call `get()` as `getAsync()`. See the [node-redis documentation](https://github.com/NodeRedis/node_redis#promises) for more details.

--- a/index.js
+++ b/index.js
@@ -1,11 +1,18 @@
 "use strict";
 
+var bluebird = require('bluebird');
 var redis = require('redis');
 var redisClientFactory = require('basic-redis-factory');
 
 exports.register = function (server, options, next) {
 
   options = options || {};
+
+  // allows for promise support when using default redis library (node_redis)
+  if (options.enablePromises && !options.redisLibrary) {
+    bluebird.promisifyAll(redis.RedisClient.prototype);
+    bluebird.promisifyAll(redis.Multi.prototype);
+  }
 
   var redisOpts = options.connection;
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "mocha": "^2.0.1"
   },
   "dependencies": {
-    "redis": "^2.3.0",
-    "basic-redis-factory": "0.0.3"
+    "basic-redis-factory": "0.0.3",
+    "bluebird": "3.2.1",
+    "redis": "^2.4.0"
   }
 }


### PR DESCRIPTION
Hi, I know there was already another PR (#7) for Promise support. Rather than making it mandatory, I made it an optional feature that works with the default Redis library. I disabled the option when specifying a different `redisLibrary` to ensure that there were no conflicts.

I also updated the Redis dependency to 2.4 as that particular release enabled TLS support when using a proxy.
